### PR TITLE
add better error messages for incomplete configuration of this plugin

### DIFF
--- a/app/Services/Client.php
+++ b/app/Services/Client.php
@@ -64,9 +64,18 @@ class Client
      */
     public static function create($appID, $appSecret, $accessToken, $pageID, $developmentMode = false)
     {
-        Type::enforce($appID, Type::STRING);
-        Type::enforce($appSecret, Type::STRING);
-        Type::enforce($accessToken, Type::STRING);
+        try {
+            Type::enforce($appID, Type::STRING);
+            Type::enforce($appSecret, Type::STRING);
+            Type::enforce($accessToken, Type::STRING);
+        } catch ( \Exception $e ) {
+?>
+            <div class="notice notice-error">
+                <p>[Facebook Instant Articles Plugin] Please complete the configuration otherwise you will not be able to save any post. <a href="http://shortlist.dev/wp/wp-admin/admin.php?page=instant-articles-index">You can complete the configuration by clicking here</a> or clicking in the "Instant Articles" menu option.</p>
+            </div>
+<?php
+            exit;
+        }
 
         $facebook = new Facebook([
             'app_id' => $appID,

--- a/app/Services/ClientProvider.php
+++ b/app/Services/ClientProvider.php
@@ -1,29 +1,21 @@
 <?php
+
 namespace AgreableInstantArticlesPlugin\Services;
 
-class ClientProvider {
-
-  function __construct() {
-
-    // String is needed for the comparison
-    if (getenv('INSTANT_ARTICLES_DEBUG') === "false") {
-      $development_mode = false;
-    } else {
-      $development_mode = true;
+class ClientProvider
+{
+    function __construct() {
+        $this->client = Client::create(
+            get_option('instant_articles_app_id'),
+            get_option('instant_articles_app_secret'),
+            get_option('instant_articles_page_token'),
+            get_option('instant_articles_page_id'),
+            getenv('INSTANT_ARTICLES_DEBUG') === "false"
+        );
     }
 
-    $this->client = Client::create(
-      get_option('instant_articles_app_id'),
-      get_option('instant_articles_app_secret'),
-      get_option('instant_articles_page_token'),
-      get_option('instant_articles_page_id'),
-      $development_mode
-    );
-  }
-
-  public function get_client_instance() {
-    return $this->client;
-  }
-
+    public function get_client_instance() {
+        return $this->client;
+    }
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -19,3 +19,18 @@ if(file_exists(__DIR__ . '/vendor/shortlist-digital/agreable-wp-plugin-framework
 } else {
   require_once __DIR__ . '/../../../../vendor/shortlist-digital/agreable-wp-plugin-framework/bootstrap/autoload.php';
 }
+
+add_action( 'admin_notices', function() {
+    if (
+        empty( get_option( 'instant_articles_app_id' ) ) ||
+        empty( get_option( 'instant_articles_app_secret' ) ) ||
+        empty( get_option( 'instant_articles_app_user_access_token' ) )
+    ) {
+?>
+    <div class="notice notice-error">
+        <p>[Facebook Instant Articles Plugin] Please complete the configuration otherwise you will not be able to save any post. <a href="http://shortlist.dev/wp/wp-admin/admin.php?page=instant-articles-index">You can complete the configuration by clicking here</a> or clicking in the "Instant Articles" menu option.</p>
+    </div>
+<?php
+    }
+
+});


### PR DESCRIPTION
Once the plugin is activated. It will try to connect to facebook IA on every `save_post`. So the configuration of the plugin has to be correct.